### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
+name: CI
 permissions:
   contents: read
-name: CI
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brduru/mcp-defect-dojo/security/code-scanning/1](https://github.com/brduru/mcp-defect-dojo/security/code-scanning/1)

**General approach:**  
Explicitly set a `permissions` block for the workflow (or for the relevant job(s)) that provides only the access necessary for the CI tasks. The safest, minimal starting point is `contents: read`, which allows the workflow to read repository contents but not to perform write operations. You should add this block at the root (preferred, so it applies to all jobs), or specifically for the `test` job if finer granularity is desired.

**Detailed fix:**  
- Add `permissions: contents: read` directly under the workflow name and before the `on:` block in `.github/workflows/ci.yml`. This ensures that none of the jobs (presently there's only the `test` job) receive broad write access via the GITHUB_TOKEN.
- No imports or external dependencies are needed for this YAML change.
- No additional methods or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
